### PR TITLE
Appa installation navigation order

### DIFF
--- a/markdown/1.0alpha1/install.html
+++ b/markdown/1.0alpha1/install.html
@@ -52,8 +52,8 @@
 			<ol>
 				<li><a href="#Installation Host Environment">Installation Host Environment</a></li>
 				<li><a href="#Partitioning">Partitioning</a></li>
-				<li><a href="#Creating the directory structure">Creating the directory structure</a></li>
 				<li><a href="#Mounting client distribution">Mounting client distribution</a></li>
+				<li><a href="#Creating the directory structure">Creating the directory structure</a></li>
 				<ol>
 					<li><a href="#Optional directories">Optional directories</a></li>
 				</ol>


### PR DESCRIPTION
As proposed by DevTwo in ##bedrock-chat, the order of the following entries in the navigation on the Appa installation page should match the order in the text:

Creating the directory structure
Mounting client distribution