### PR TITLE
Fixing broken reddit links.

### DIFF
--- a/markdown/1.0beta2/install.md
+++ b/markdown/1.0beta2/install.md
@@ -1077,4 +1077,4 @@ If you run into any difficulties, try reviewing the relevant documentation
 pages for this release, and if that doesn't help sufficiently, don't hesitate
 to drop into the [IRC channel](https://webchat.freenode.net/?channels=bedrock),
 the [forums](http://www.linuxquestions.org/questions/bedrock-linux-118/), or
-[subreddit](reddit.com/r/bedrocklinux).
+[subreddit](https://www.reddit.com/r/bedrocklinux).

--- a/markdown/1.0beta2/quickstart.md
+++ b/markdown/1.0beta2/quickstart.md
@@ -431,4 +431,4 @@ If you run into any difficulties, try reviewing the relevant documentation
 pages for this release, and if that doesn't help sufficiently, don't hesitate
 to drop into the [IRC channel](https://webchat.freenode.net/?channels=bedrock),
 the [forums](http://www.linuxquestions.org/questions/bedrock-linux-118/), or
-[subreddit](reddit.com/r/bedrocklinux).
+[subreddit](https://www.reddit.com/r/bedrocklinux).


### PR DESCRIPTION
Currently on the site the links are showing as: http://bedrocklinux.org/1.0beta2/reddit.com/r/bedrocklinux due to missing the protocol and/or www.