### PR TITLE
Update configure-rootfs anchor for typo.

### DIFF
--- a/markdown/1.0beta2/install.md
+++ b/markdown/1.0beta2/install.md
@@ -11,7 +11,7 @@ Bedrock Linux 1.0beta2 Nyla Installation Instructions
 - [Install Bedrock Linux userland](#install-userland)
 - [Acquire other strata](#acquire-strata)
 - [Configure](#configure)
-	- [Configure rootfs stratum](#configure-roofs)
+	- [Configure rootfs stratum](#configure-rootfs)
 	- [Configure global stratum](#configure-global)
 	- [Configure time](#configure-time)
 	- [Configure init](#configure-init)
@@ -380,7 +380,7 @@ cover the minimum you need to configure before booting into Bedrock Linux,
 skipping some of the details on what is going on under-the-hood.  If you would
 like further details on configuration, see [here](configure.html).
 
-### {id="configure-roofs"} Configure rootfs stratum
+### {id="configure-rootfs"} Configure rootfs stratum
 
 All of Bedrock Linux's files have some corresponding ~{stratum~}.  `/boot`,
 `/bedrock`, and if you are doing a hijack install, the hijacked


### PR DESCRIPTION
This part

> Consider skimming the rootfs section and the global section of the installation docs to understand the significance of this (then return here).

was referencing to `#configure-rootfs` already. A quick `ag` on the repo did not find any other internal reference to the `#configure-roofs` typo, but **this might break external links**. In the event the external links are more important than correctness, the fix should instead change that link to use the erroneous `#configure-roofs`.