### PR TITLE
Fixed Alpine “No hostname” instructions and a typo

### DIFF
--- a/markdown/1.0beta2/strata.md
+++ b/markdown/1.0beta2/strata.md
@@ -402,7 +402,7 @@ Clean up:
 Enable desired openrc services, such as hostname:
 
 - {class="rcmd"}
-- ln -s hostname /bedrock/strata/~(alpine~)/etc/init.d/hostname
+- rc-update add hostname default
 
 Finally, create an entry in `/bedrock/etc/strata.conf` file as explained
 in [the configuration page](configure.html), such as:

--- a/markdown/1.0beta2/strata.md
+++ b/markdown/1.0beta2/strata.md
@@ -402,7 +402,7 @@ Clean up:
 Enable desired openrc services, such as hostname:
 
 - {class="rcmd"}
-- rc-update add hostname default
+- chroot /bedrock/strata/~(alpine~) rc-update add hostname default
 
 Finally, create an entry in `/bedrock/etc/strata.conf` file as explained
 in [the configuration page](configure.html), such as:

--- a/markdown/1.0beta2/troubleshooting.md
+++ b/markdown/1.0beta2/troubleshooting.md
@@ -33,8 +33,6 @@ and ~{strata~} for Bedrock Linux 1.0beta2 Nyla.
 		- [Slow boot](#crux-slow-boot)
 		- [Freeze on shutdown](#crux-shutdown-freeze)
 		- [Timezone](#crux-timezone)
-	- [Alpine](#alpine)
-		- [No hostname](#alpine-no-hostname)
 
 ## {id="tips"} Tips
 
@@ -382,15 +380,4 @@ to
     #fi
 
 This will force CRUX to use `/etc/localtime`, which (with default Bedrock Linux
-configuration) will be a copy of `/bedock/etc/localtime`.
-
-### {id="alpine"} Alpine
-
-#### {id="alpine-no-hostname"} No hostname
-
-If acquired via [Alpine stratum acquiring instructions](strata.html#alpine),
-the openrc service to set the hostname is not enabled by default, and thus the
-hostname is not set.  To enable it at boot, run
-
-- {class="rcmd"}
-- ln -s hostname /bedrock/strata/~(alpine~)/etc/init.d/hostname
+configuration) will be a copy of `/bedrock/etc/localtime`


### PR DESCRIPTION
I removed the instructions in troubleshooting.md altogether since it was telling you to use them if you followed strata.md, basically having you repeat it when doing so doesn’t change anything.