### PR TITLE
propably typo

### DIFF
--- a/markdown/0.7/commands.md
+++ b/markdown/0.7/commands.md
@@ -210,7 +210,7 @@ For example:
 - {class="rcmd"}
 - brl rename ubuntu bionic
 
-`brl remove` also renames ~{aliases~}.
+`brl rename` also renames ~{aliases~}.
 
 The `bedrock` ~{stratum~} cannot be renamed, as it internally has hard-coded
 references to itself which are essential for the system to function.


### PR DESCRIPTION
In current website is: "brl remove also renames aliases" which sounds wrong to me and propably was meant: "brl rename also renames aliases".