### PR TITLE
Fix duplicate words and typos in multiple markdown files

### DIFF
--- a/markdown/0.7/beta-channel.md
+++ b/markdown/0.7/beta-channel.md
@@ -39,7 +39,7 @@ When you next `brl update` it will look for the newest available update, stable 
 
 ## {id="reverting-to-stable"} Reverting to the stable channel
 
-To revert to the stable channel, first first change the `mirrors` field under either `[miscellaneous]` or `[brl-update]` in your `/bedrock/etc/bedrock.conf` to only check the stable channel:
+To revert to the stable channel, first change the `mirrors` field under either `[miscellaneous]` or `[brl-update]` in your `/bedrock/etc/bedrock.conf` to only check the stable channel:
 
 `mirrors = https://raw.githubusercontent.com/bedrocklinux/bedrocklinux-userland/0.7/releases`
 

--- a/markdown/0.7/commands.md
+++ b/markdown/0.7/commands.md
@@ -174,7 +174,7 @@ perform some action `qemu-user-static` does not yet support, it will not work.
 
 ~+Bedrock~x provides a `brl import` command to create strata from on-disk
 sources.   This may be useful for distros that `brl fetch` does not support or
-for for use with offline systems.
+for use with offline systems.
 
 To import a stratum, run
 

--- a/markdown/0.7/extending.md
+++ b/markdown/0.7/extending.md
@@ -388,8 +388,8 @@ where:
   operation should apply to.  It may be overridden by `pmm` flags such as
 `--every` and `--newest`.  Valid values are:
 	- "first": Use first package manager which passes applicability-check.
-	- "every": Use every package manager which which passes
-	  applicability-check
+	- "every": Use every package manager which passes
+	  applicability-check.
 	- "none":  No package managers are applicable; used for `pmm` specific
 	  operations which do not correlate to individual package managers.
 

--- a/markdown/0.7/feature-compatibility.md
+++ b/markdown/0.7/feature-compatibility.md
@@ -139,7 +139,7 @@ The wiring between these components does not work automatically register across
   configuration also remains an open research problem](#init-configuration).
 - DMs learn about DEs via files in `/usr/share/xsessions/` and only in that
   location.  Unlike other resources, there does not appear to be a standard way
-  to to extend the list of resource look-up locations.  Consequently, there's
+  to extend the list of resource look-up locations.  Consequently, there's
   no obvious way to add cross-stratum DE registration without risking upsetting
   a package manager.
 

--- a/markdown/0.8/plans.md
+++ b/markdown/0.8/plans.md
@@ -62,7 +62,7 @@ Nyla's development will shift documentation into a single source from which the 
 
 ## {id="fuse-fs-arch"} crossfs and etcfs modular architecture.
 
-Over Poki's life, crossfs and etcfs have not evolved quite as originally expected, and technical debt is slowing slowing further development.  They will be rewritten with the following architecture in order to expedite future development:
+Over Poki's life, crossfs and etcfs have not evolved quite as originally expected, and technical debt is slowing further development.  They will be rewritten with the following architecture in order to expedite future development:
 
 - A core that:
 	- Reads Bedrock configuration

--- a/markdown/contributing.md
+++ b/markdown/contributing.md
@@ -20,7 +20,7 @@ Helping here would free up limited resources for research and development
 efforts.
 
 Consider learning ~+Bedrock Linux~x well yourself, such as from using it and
-watching others answer questions.  Then, once you are adequately knowledgable,
+watching others answer questions.  Then, once you are adequately knowledgeable,
 consider watching places such as:
 
 - [IRC: #bedrock on libera.chat](https://libera.chat)


### PR DESCRIPTION
Did some grepping and found some duplicate words