### PR TITLE
Use more streamlined and inclusive pronouns on the distro compatibilty page

### DIFF
--- a/markdown/0.7/distro-compatibility.md
+++ b/markdown/0.7/distro-compatibility.md
@@ -61,7 +61,7 @@ non-local components, such as `/etc` files, changing out from under it.
 over `/etc` file changes.
 
 ~+Solus~x _does_ provide default versions of these files, but outside of
-`/etc`.  The expectation might be that the user copies them over at his/her
+`/etc`.  The expectation might be that the user copies them over at their
 whim.
 
 This is likely removable with adequate effort.  ~+Bedrock~x could be configured


### PR DESCRIPTION
`his/her` is clunky and sounds bad. `their` is significantly more streamlined and also has the added benefit of not excluding the probably tiny but still existent group of users/potential users who do not fit into either category. 