### PR TITLE
There was a pipe missing for the Fedora entry on the distro compatibility page

### DIFF
--- a/markdown/0.7/distro-compatibility.md
+++ b/markdown/0.7/distro-compatibility.md
@@ -19,7 +19,7 @@ confidence in the "Known Issues" column's accuracy and recency.
 | ~+Elementary OS~x     | ~!Very Low~x      | ~%None~x     | ~!No~x           | ~!None~x     |
 | ~+EndeavorOS~x        | ~!Very Low~x      | ~%None~x     | ~!No~x           | ~!None~x     |
 | ~+Exherbo~x           | ~^Medium~x        | ~%None~x     | ~%Yes~x          | ~!None~x     |
-| ~+Fedora~x            | ~^Medium~x        | ~!defaults to grub+btrfs~x [†](feature-compatibility.html#grub-btrfs-zfs) ~%Yes~x          | ~%paradigm~x |
+| ~+Fedora~x            | ~^Medium~x        | ~!defaults to grub+btrfs~x [†](feature-compatibility.html#grub-btrfs-zfs) | ~%Yes~x          | ~%paradigm~x |
 | ~+Fedora Silverblue~x | ~!None~x          | ~!Read-only root~x [†](#silverblue) | ~!No~x | ~!None~x |
 | ~+Gentoo Linux~x      | ~%High~x          | ~%None~x     | ~%Yes~x          | ~%paradigm~x |
 | ~+GoboLinux~x         | ~!None~x          | ~%None~x     | ~!No~x           | ~!None~x     |

--- a/markdown/0.7/feature-compatibility.md
+++ b/markdown/0.7/feature-compatibility.md
@@ -61,7 +61,7 @@ Miscellaneous known feature-specific issues and limitations.
 | pamac/octopi                                    | ~!Inconsistent Reports~x | [Inconsistent reports](#pamac) |
 | ptrace (e.g. gdb, strace)                       | ~^Minor Work-around~x    | Install in same ~{stratum~} as traced program, `strat -r` |
 | SELinux                                         | ~!Does Not Work~x        | ~+Bedrock~x disabled on hijack |
-| Shadow password hashing and login               | ~^Minor Work-around~x    | [Differing shadow versions(#shadow-login)]
+| Shadow password hashing and login               | ~^Minor Work-around~x    | [Differing shadow versions](#shadow-login)
 | systemd-shim                                    | ~!Major Issue~x          | [logind access denied](#systemd-shim) |
 | timeshift                                       | ~!Major Issue~x          | Confused by filesystem layout; do not use with ~+Bedrock~x |
 
@@ -194,8 +194,8 @@ It is not clear why this might not be happening during SysV shutdown.
 ~+Bedrock~x's `etcfs` code does not do any direct signal handling.  Debugging
 this may require digging into `libfuse`'s code to see how it handles signals.
 
-### {id="shadow-login"}
-On some ~{strata~}, certian hashing algorithms aren't supported due to differences
+### {id="shadow-login"} Differing shadow versions
+On some ~{strata~}, certain hashing algorithms aren't supported due to differences
 in `shadow` versions. This can cause faliure to login with a `login incorrect`
 error or equivalent when using a ~{stratum~}'s init that didn't create the hash with
 `passwd`.


### PR DESCRIPTION
There was a pipe missing for the Fedora entry on the distro compatibility page.  First pull request ever.